### PR TITLE
Added a paragraph to remove confusion about body and template

### DIFF
--- a/content/blaze/step02.md
+++ b/content/blaze/step02.md
@@ -20,9 +20,11 @@ Now let's find out what all these bits of code are doing!
 
 Meteor parses all of the HTML files in your app folder and identifies three top-level tags: **&lt;head>**, **&lt;body>**, and **&lt;template>**.
 
-Everything inside any &lt;head> tags is added to the `head` section of the HTML sent to the client, and everything inside &lt;body> tags is added to the `body` section, just like in a regular HTML file.
+Everything inside any &lt;head> tags is added to the `head` section of the HTML sent to the client, and everything inside &lt;body> tags is added to the `body` section, just like in a regular HTML file. 
 
 Everything inside &lt;template> tags is compiled into Meteor _templates_, which can be included inside HTML with `{{dstache}}> templateName}}` or referenced in your JavaScript with `Template.templateName`.
+
+Also, the `body` section can be referenced in your JavaScript with `Template.body`. Think of it as a special "parent" template, that can include the other child templates. 
 
 ### Adding logic and data to templates
 


### PR DESCRIPTION
As a beginner, I got confused about how body was handled separately from templates, because "Template.body" and "Template.myTemplate" were both being used without (IMHO) adequate explanation. 

On googling, I found:
1. this StackOverflow question: http://stackoverflow.com/questions/29947563/template-body-vs-template-mytemplate/29948336#29948336
2. Meteor open issue: https://github.com/meteor/meteor/issues/4176
3. Tutorials open issue: https://github.com/meteor/tutorials/issues/21

I thought I'd suggest the changes to the tutorial in a pull request, so this could be resolved and avoid further confusion to other beginners.
