### PR TITLE
Updated the documentation with information about missing imports folder

### DIFF
--- a/content/blaze/step02.md
+++ b/content/blaze/step02.md
@@ -13,7 +13,7 @@ Then we create some new files in the `imports/` directory:
 
 {{> DiffBox tutorialName="simple-todos" step="2.3"}}
 
-Files inside `imports/` only load if they are imported, so we'll need to import `imports/ui/body.js` from our frontend JS entrypoint (`client/main.js`---note that we remove the rest of the code from this file):
+Create an `imports` folder inside the `simple-todos` folder.Files inside `imports/` only load if they are imported, so we'll need to import `imports/ui/body.js` from our frontend JS entrypoint (`client/main.js`---note that we remove the rest of the code from this file):
 
 {{> DiffBox tutorialName="simple-todos" step="2.4"}}
 


### PR DESCRIPTION
The document directly talks about importing files inside the `imports` folder. However, I realized that the `imports` folder doesn't exist inside the `simple-todos` folder . It wasn't clear after reading the documentation where does this `imports` folder come from and hence I updated the documentation so that the new users would know that they would need to create the `imports` folder and then proceed forward with the tutorial.
