### PR TITLE
Fix broken link to Spacebars information from Step 2 in Blaze tutorial

### DIFF
--- a/content/blaze/step02.md
+++ b/content/blaze/step02.md
@@ -40,7 +40,7 @@ Also, the `body` section can be referenced in your JavaScript with `Template.bod
 
 ### Adding logic and data to templates
 
-All of the code in your HTML files is compiled with [Meteor's Spacebars compiler](https://github.com/meteor/meteor/blob/devel/packages/spacebars/README.md). Spacebars uses statements surrounded by double curly braces such as `{{dstache}}#each}}` and `{{dstache}}#if}}` to let you add logic and data to your views.
+All of the code in your HTML files is compiled with [Meteor's Spacebars compiler](http://blazejs.org/api/spacebars.html). Spacebars uses statements surrounded by double curly braces such as `{{dstache}}#each}}` and `{{dstache}}#if}}` to let you add logic and data to your views.
 
 You can pass data into templates from your JavaScript code by defining _helpers_. In the code above, we defined a helper called `tasks` on `Template.body` that returns an array. Inside the body tag of the HTML, we can use `{{dstache}}#each tasks}}` to iterate over the array and insert a `task` template for each value. Inside the `#each` block, we can display the `text` property of each array item using `{{dstache}}text}}`.
 


### PR DESCRIPTION
Since `spacebars` is no longer in meteor/meteor and has been moved to Blaze, the readme was no longer in place at its previous location.  This updates the link in the tutorial to point to the new home on blazejs.org and also points to a more helpful page than the nearly empty README.

Originally reported in meteor/meteor#8167
Fixes meteor/tutorials#96