### PR TITLE
Add clarification about the importance of `meteor npm`.

### DIFF
--- a/content/angular/step02.md
+++ b/content/angular/step02.md
@@ -15,6 +15,8 @@ To start working with [angular-meteor](http://angular-meteor.com/), let's add so
 
     meteor npm install --save angular angular-meteor
 
+> Note: `meteor npm` supports the same features as `npm`, though the difference can be important.  Consult the [`meteor npm` documentation](https://docs.meteor.com/commandline.html#meteornpm) for more information.
+
 To start working on our todos list app, let's replace the code of the default starter app with the code below. Then we'll talk about what it does.
 
 {{> DiffBox tutorialName="simple-todos-angular" step="2.2"}}

--- a/content/react/step02.md
+++ b/content/react/step02.md
@@ -9,6 +9,8 @@ Open a new terminal in the same directory as your running app, and type:
 meteor npm install --save react react-dom
 ```
 
+> Note: `meteor npm` supports the same features as `npm`, though the difference can be important.  Consult the [`meteor npm` documentation](https://docs.meteor.com/commandline.html#meteornpm) for more information.
+
 ### Replace the starter code
 
 To get started, let's replace the code of the default starter app. Then we'll talk about what it does.

--- a/content/shared/step01.md
+++ b/content/shared/step01.md
@@ -30,8 +30,6 @@ meteor npm install
 meteor
 ```
 
-> Note: `meteor npm` supports the same features as `npm`, though the difference can be important.  Consult the [`meteor npm` documentation](https://docs.meteor.com/commandline.html#meteornpm) for more information.
-
 Open your web browser and go to `http://localhost:3000` to see the app running.
 
 You can play around with this default app for a bit before we continue. For example, try editing the text in `<h1>` inside `client/main.html` using your favorite text editor. When you save the file, the page in your browser will automatically update with the new content. We call this "hot code push".

--- a/content/shared/step01.md
+++ b/content/shared/step01.md
@@ -30,6 +30,8 @@ meteor npm install
 meteor
 ```
 
+> Note: `meteor npm` supports the same features as `npm`, though the difference can be important.  Consult the [`meteor npm` documentation](https://docs.meteor.com/commandline.html#meteornpm) for more information.
+
 Open your web browser and go to `http://localhost:3000` to see the app running.
 
 You can play around with this default app for a bit before we continue. For example, try editing the text in `<h1>` inside `client/main.html` using your favorite text editor. When you save the file, the page in your browser will automatically update with the new content. We call this "hot code push".


### PR DESCRIPTION
At an early step in the tutorial, failure to explain the distinction
between `meteor npm` and `npm` could be confusing and this is a
perfect opportunity to ensure that developers understand its importance
over the lifetime of their Meteor development.

Helps with meteor/tutorials#68.

Depends on https://github.com/meteor/docs/pull/127.