### PR TITLE
Instruct creation of the `imports` directory and clarify its purpose.

### DIFF
--- a/content/angular/step02.md
+++ b/content/angular/step02.md
@@ -21,11 +21,15 @@ To start working on our todos list app, let's replace the code of the default st
 
 {{> DiffBox tutorialName="simple-todos-angular" step="2.3"}}
 
-Let's create a template for todosList component.
+Now we need to create a new directory called `imports`, a specially-named directory which will behave different than other directories in the project.  Files outside the `imports` directory will be loaded automatically when the Meteor server starts, while files inside the `imports` directory will only load when an `import` statement is used to load them.
+
+After creating the `imports` directory, we will create new two new files inside it.
+
+A template for the todosList component:
 
 {{> DiffBox tutorialName="simple-todos-angular" step="2.4"}}
 
-Add some functionality:
+And some functionality:
 
 {{> DiffBox tutorialName="simple-todos-angular" step="2.5"}}
 
@@ -38,6 +42,8 @@ First, we have to put component into a template:
 Then add module to the application:
 
 {{> DiffBox tutorialName="simple-todos-angular" step="2.7"}}
+
+You can read more about how imports work and how to structure your code in the [Application Structure article](http://guide.meteor.com/structure.html) of the Meteor Guide.
 
 In our browser, the app should look pretty much like this:
 

--- a/content/angular/step02.md
+++ b/content/angular/step02.md
@@ -21,9 +21,9 @@ To start working on our todos list app, let's replace the code of the default st
 
 {{> DiffBox tutorialName="simple-todos-angular" step="2.3"}}
 
-Now we need to create a new directory called `imports`, a specially-named directory which will behave different than other directories in the project.  Files outside the `imports` directory will be loaded automatically when the Meteor server starts, while files inside the `imports` directory will only load when an `import` statement is used to load them.
+Now we need to create a new directory called `imports`, a specially-named directory which will behave differently than other directories in the project.  Files outside the `imports` directory will be loaded automatically when the Meteor server starts, while files inside the `imports` directory will only load when an `import` statement is used to load them.
 
-After creating the `imports` directory, we will create new two new files inside it.
+After creating the `imports` directory, we will create two new files inside it.
 
 A template for the todosList component:
 

--- a/content/blaze/step02.md
+++ b/content/blaze/step02.md
@@ -3,7 +3,7 @@
 
 To start working on our todo list app, let's replace the code of the default starter app with the code below. Then we'll talk about what it does.
 
-First, let's remove the body from our HTML entry point (leaving just the `<head>` tag):
+First, let's remove the body from our HTML entry-point (leaving just the `<head>` tag):
 
 {{> DiffBox tutorialName="simple-todos" step="2.1"}}
 
@@ -13,7 +13,7 @@ Create a new directory with the name `imports` inside `simple-todos` folder.Then
 
 {{> DiffBox tutorialName="simple-todos" step="2.3"}}
 
-Files inside `imports/` only load if they are imported, so we'll need to import `imports/ui/body.js` from our frontend JS entrypoint (`client/main.js`---note that we remove the rest of the code from this file):
+Inside our front-end JavaScript entry-point file, `client/main.js`, we'll _remove_ the rest of the code and import `imports/ui/body.js`:
 
 {{> DiffBox tutorialName="simple-todos" step="2.4"}}
 

--- a/content/react/step02.md
+++ b/content/react/step02.md
@@ -17,9 +17,13 @@ First, replace the content of the initial HTML file:
 
 {{> DiffBox tutorialName="simple-todos-react" step="2.2"}}
 
-Second, **delete `client/main.js`** and create three new files:
+Second, **delete `client/main.js`** and create this file:
 
 {{> DiffBox tutorialName="simple-todos-react" step="2.3"}}
+
+Now we need to create a new directory called `imports`, a specially-named directory which will behave different than other directories in the project.  Files outside the `imports` directory will be loaded automatically when the Meteor server starts, while files inside the `imports` directory will only load when an `import` statement is used to load them.
+
+After creating the `imports` directory, we will create new two new files inside it:
 
 {{> DiffBox tutorialName="simple-todos-react" step="2.4"}}
 

--- a/content/react/step02.md
+++ b/content/react/step02.md
@@ -21,9 +21,9 @@ Second, **delete `client/main.js`** and create this file:
 
 {{> DiffBox tutorialName="simple-todos-react" step="2.3"}}
 
-Now we need to create a new directory called `imports`, a specially-named directory which will behave different than other directories in the project.  Files outside the `imports` directory will be loaded automatically when the Meteor server starts, while files inside the `imports` directory will only load when an `import` statement is used to load them.
+Now we need to create a new directory called `imports`, a specially-named directory which will behave differently than other directories in the project.  Files outside the `imports` directory will be loaded automatically when the Meteor server starts, while files inside the `imports` directory will only load when an `import` statement is used to load them.
 
-After creating the `imports` directory, we will create new two new files inside it:
+After creating the `imports` directory, we will create two new files inside it:
 
 {{> DiffBox tutorialName="simple-todos-react" step="2.4"}}
 


### PR DESCRIPTION
Previously, we failed to explicitly instruct the developer to create the
`imports` directory on the Blaze, Angular and React tutorials.  While
the path was implied in the top-right corner of the code-snippet boxes,
we should be more clear about this and we can also take the opportunity
to emphasize the importance and significance of the directory.

We do mention a place to find more information about how imports work,
but not until a later step.  This information was also excluded from the
Angular tutorial, so this also adds the same blurb for that.

Follows-up on meteor/tutorials#86.

This also fixes the phrase "entry point" to be consistently represented as two distinct words.  I'm not sure if "entry point" should be hyphenated or not and have gone with the hyphenated approach as I believe it's most appropriate, but "entrypoint" is definitely not a word.  Happy to remove the hyphen but I don't know if there's a right answer.

(Also, a couple other minor grammatical changes.)

/cc @lazaridis-com 