### PR TITLE
Clarify that we are removing the collection to avoid confusion.

### DIFF
--- a/content/blaze/step09.md
+++ b/content/blaze/step09.md
@@ -24,6 +24,8 @@ Now that we have defined our methods, we need to update the places we were opera
 
 {{> DiffBox tutorialName="simple-todos" step="9.3"}}
 
+We do the same on this file, but also remove the `import` of the `Tasks` collection since it's no longer necessary:
+
 {{> DiffBox tutorialName="simple-todos" step="9.4"}}
 
 Now all of our inputs and buttons will start working again. What did we gain from all of this work?


### PR DESCRIPTION
The `Tasks` import disappearing could be confusing and it wouldn't hurt to explain this briefly.

Closes meteor/tutorials#79