### PR TITLE
Update step02.md

### DIFF
--- a/content/react/step02.md
+++ b/content/react/step02.md
@@ -6,7 +6,7 @@ To start working with React as our view library, let's add some NPM packages whi
 Open a new terminal in the same directory as your running app, and type:
 
 ```sh
-meteor npm install --save react react-dom
+meteor npm install --save react react-dom prop-types
 ```
 
 > Note: `meteor npm` supports the same features as `npm`, though the difference can be important.  Consult the [`meteor npm` documentation](https://docs.meteor.com/commandline.html#meteornpm) for more information.


### PR DESCRIPTION
Updated meteor npm install to include the prop-types package. Without using the prop-types package, this error shows in the console.

`Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.`

[Pull request for tutorial change.](https://github.com/meteor/simple-todos-react/pull/52)