### PR TITLE
Remove step 10.6

### DIFF
--- a/content/react/step10.md
+++ b/content/react/step10.md
@@ -30,15 +30,13 @@ Let's add another property to tasks called "private" and a button for users to m
 
 First, we need to add a new method that we can call to set a task's private status:
 
-{{> DiffBox step="10.4" tutorialName="simple-todos-react"}} 
+{{> DiffBox step="10.4" tutorialName="simple-todos-react"}}
 
 Now, we need to pass a new property to the `Task` to decide whether we want
 to show the private button; the button should show up only if the currently
 logged in user owns this task:
 
 {{> DiffBox step="10.5" tutorialName="simple-todos-react"}}
-
-{{> DiffBox step="10.6" tutorialName="simple-todos-react"}}
 
 Let's add the button, using this new prop to decide whether it should be displayed:
 


### PR DESCRIPTION
Step 10.6 is no longer needed (since it had to do exclusively with `React.PropTypes`).