### PR TITLE
Add a new custom step11.md for react

### DIFF
--- a/content/react/metadata.js
+++ b/content/react/metadata.js
@@ -63,12 +63,12 @@ TutorialRegistry.registerTutorial("react", {
     {
       title: 'Testing',
       slug: "testing",
-      template: 'sharedStep11'
+      template: 'react-step11'
     },
     {
       title: 'Next steps',
       slug: "next-steps",
-      template: 'react-step11'
+      template: 'react-step12'
     }
   ]
 });

--- a/content/react/step11.md
+++ b/content/react/step11.md
@@ -1,20 +1,40 @@
 {{#template name="react-step11"}}
 
-# What's next?
+# Testing
 
-Congratulations on your newly built Meteor app!
+Now that we've created a few features for our application, let's add a test to ensure that we don't regress and that it works the way we expect.
 
-Your app currently supports collaborating on a single todo list. To see how you
-could add more functionality, check out the Todos example &mdash; a more
-complete app that can handle sharing multiple lists. Also, try Local Market, a
-cross-platform customer engagement app that shows off native hardware
-functionality and social features.
+We'll write a test that exercises one of our Methods (which form the "write" part of our app's API), and verifies it works correctly.
+
+To do so, we'll add a [test driver](http://guide.meteor.com/testing.html#test-driver) for the [Mocha](https://mochajs.org) JavaScript test framework, along with a test assertion library:
 
 ```bash
-meteor create --example todos
-meteor create --example localmarket
+meteor add meteortesting:mocha
+meteor npm install --save-dev chai
 ```
 
-{{> step11NextSteps}}
+We can now run our app in "test mode" by calling out a special command and specifying to use the driver (you'll need to stop the regular app from running, or specify an alternate port with `--port XYZ`):
+
+```bash
+TEST_WATCH=1 meteor test --driver-package meteortesting:mocha
+```
+
+If you do so, you should see a `0 passing` message in your console window.
+
+Let's add a simple test (that doesn't do anything yet):
+
+{{> DiffBox tutorialName="simple-todos" step="11.2"}}
+
+In any test we need to ensure the database is in the state we expect before beginning. We can use Mocha's `beforeEach` construct to do that easily:
+
+{{> DiffBox tutorialName="simple-todos" step="11.3"}}
+
+Here we create a single task that's associated with a random `userId` that'll be different for each test run.
+
+Now we can write the test to call the `tasks.remove` method "as" that user and verify the task is deleted:
+
+{{> DiffBox tutorialName="simple-todos" step="11.4"}}
+
+There's a lot more you can do in a Meteor test! You can read more about it in the Meteor Guide [article on testing](http://guide.meteor.com/testing.html).
 
 {{/template}}

--- a/content/react/step12.md
+++ b/content/react/step12.md
@@ -1,0 +1,20 @@
+{{#template name="react-step12"}}
+
+# What's next?
+
+Congratulations on your newly built Meteor app!
+
+Your app currently supports collaborating on a single todo list. To see how you
+could add more functionality, check out the Todos example &mdash; a more
+complete app that can handle sharing multiple lists. Also, try Local Market, a
+cross-platform customer engagement app that shows off native hardware
+functionality and social features.
+
+```bash
+meteor create --example todos
+meteor create --example localmarket
+```
+
+{{> step11NextSteps}}
+
+{{/template}}

--- a/content/shared/step11.md
+++ b/content/shared/step11.md
@@ -6,20 +6,19 @@ Now that we've created a few features for our application, let's add a test to e
 
 We'll write a test that exercises one of our Methods (which form the "write" part of our app's API), and verifies it works correctly.
 
-To do so, we'll add a [test driver](http://guide.meteor.com/testing.html#test-driver) for the [Mocha](https://mochajs.org) JavaScript test framework, along with a test assertion library:
+To do so, we'll add a [test driver](http://guide.meteor.com/testing.html#test-driver) for the [Mocha](https://mochajs.org) JavaScript test framework:
 
 ```bash
-meteor add meteortesting:mocha
-meteor npm install --save-dev chai
+meteor add practicalmeteor:mocha
 ```
 
 We can now run our app in "test mode" by calling out a special command and specifying to use the driver (you'll need to stop the regular app from running, or specify an alternate port with `--port XYZ`):
 
 ```bash
-TEST_WATCH=1 meteor test --driver-package meteortesting:mocha
+meteor test --driver-package practicalmeteor:mocha
 ```
 
-If you do so, you should see a `0 passing` message in your console window.
+If you do so, you should see an empty test results page in your browser window.
 
 Let's add a simple test (that doesn't do anything yet):
 


### PR DESCRIPTION
I had originally updated the `shared/step11.md` file to show how to use `meteortesting:mocha` instead of `practicalmeteor:mocha`, but since we're just working on updating the react tutorial right now, I've decided to revert these changes. Instead, I've created a new react specific `react/step11.md` file with the `meteortesting:mocha` changes.