### PR TITLE
Remove shared/step11.md

### DIFF
--- a/content/blaze/metadata.js
+++ b/content/blaze/metadata.js
@@ -63,7 +63,7 @@ TutorialRegistry.registerTutorial("blaze", {
     {
       title: 'Testing',
       slug: "testing",
-      template: 'sharedStep11'
+      template: 'blaze-step11'
     },
     {
       title: 'Next steps',

--- a/content/blaze/step11.md
+++ b/content/blaze/step11.md
@@ -1,4 +1,4 @@
-{{#template name="sharedStep11"}}
+{{#template name="blaze-step11"}}
 
 # Testing
 

--- a/content/react/step11.md
+++ b/content/react/step11.md
@@ -23,17 +23,17 @@ If you do so, you should see a `0 passing` message in your console window.
 
 Let's add a simple test (that doesn't do anything yet):
 
-{{> DiffBox tutorialName="simple-todos" step="11.2"}}
+{{> DiffBox tutorialName="simple-todos-react" step="11.2"}}
 
 In any test we need to ensure the database is in the state we expect before beginning. We can use Mocha's `beforeEach` construct to do that easily:
 
-{{> DiffBox tutorialName="simple-todos" step="11.3"}}
+{{> DiffBox tutorialName="simple-todos-react" step="11.3"}}
 
 Here we create a single task that's associated with a random `userId` that'll be different for each test run.
 
 Now we can write the test to call the `tasks.remove` method "as" that user and verify the task is deleted:
 
-{{> DiffBox tutorialName="simple-todos" step="11.4"}}
+{{> DiffBox tutorialName="simple-todos-react" step="11.4"}}
 
 There's a lot more you can do in a Meteor test! You can read more about it in the Meteor Guide [article on testing](http://guide.meteor.com/testing.html).
 

--- a/package.js
+++ b/package.js
@@ -46,6 +46,7 @@ Package.onUse(function (api) {
     'content/blaze/step08.md',
     'content/blaze/step09.md',
     'content/blaze/step10.md',
+    'content/blaze/step11.md',
     'content/blaze/step12.md',
 
     'content/react/step02.md',
@@ -57,6 +58,7 @@ Package.onUse(function (api) {
     'content/react/step09.md',
     'content/react/step10.md',
     'content/react/step11.md',
+    'content/react/step12.md',
     'content/step00.html',
 
     'content/shared/explanations.md',
@@ -65,7 +67,6 @@ Package.onUse(function (api) {
     'content/shared/nextSteps.md',
     'content/shared/step01.md',
     'content/shared/step06.md',
-    'content/shared/step11.md',
 
     'generated/react.multi.patch',
     'generated/blaze.multi.patch',


### PR DESCRIPTION
It turns out the angular tutorial is using its own `step11.md`, so now that the react tutorial is as well, there isn't really a reason to have the blaze tutorial refer to a `shared/step11.md`. This commit creates a Blaze specific `blaze/step11.md`.