### PR TITLE
Issue 164: Step 2.2 talk only about `imports/` then uses `imports/ui/`

### DIFF
--- a/content/blaze/step02.md
+++ b/content/blaze/step02.md
@@ -7,7 +7,7 @@ First, let's remove the body from our HTML entry-point (leaving just the `<head>
 
 {{> DiffBox tutorialName="simple-todos" step="2.1"}}
 
-Create a new directory with the name `imports` inside `simple-todos` folder. Then we create some new files in the `imports/` directory:
+Create a new directories with the name `imports/ui/` inside `simple-todos` folder. Then we create some new files in the `imports/ui/` directory:
 
 {{> DiffBox tutorialName="simple-todos" step="2.2"}}
 

--- a/content/blaze/step02.md
+++ b/content/blaze/step02.md
@@ -7,7 +7,7 @@ First, let's remove the body from our HTML entry-point (leaving just the `<head>
 
 {{> DiffBox tutorialName="simple-todos" step="2.1"}}
 
-Create a new directories with the name `imports/ui/` inside `simple-todos` folder. Then we create some new files in the `imports/ui/` directory:
+Create a new directory with the path `imports/ui/` inside `simple-todos` folder. Then we create some new files in the `imports/ui/` directory:
 
 {{> DiffBox tutorialName="simple-todos" step="2.2"}}
 


### PR DESCRIPTION
https://github.com/meteor/tutorials/issues/164

Step 2.2 talk only about `imports/` then uses `imports/ui/`
"Create a new directory with the name imports inside simple-todos folder. Then we create some new files in the imports/ directory:"
Files locations are `imports/ui/body.html` and `imports/ui/body.js`

between 2.3 to 2.4 it already mentions `imports/ui/body.js`
and 2.4 has an include of `import '../imports/ui/body.js';`