### PR TITLE
Added Remove Blaze Step in react/step02.md

### DIFF
--- a/content/react/step02.md
+++ b/content/react/step02.md
@@ -11,9 +11,18 @@ meteor npm install --save react react-dom
 
 > Note: `meteor npm` supports the same features as `npm`, though the difference can be important.  Consult the [`meteor npm` documentation](https://docs.meteor.com/commandline.html#meteornpm) for more information.
 
+### Remove Blaze
+
+Every new Meteor app includes Blaze, Meteor’s default templating system, by default. As we are not [using React and Blaze together](https://guide.meteor.com/react.html#using-with-blaze) in this application, we'll need to remove Blaze by executing the following commands:
+
+```sh
+meteor remove blaze-html-templates
+meteor add static-html
+```
+
 ### Replace the starter code
 
-To get started, let's replace the code of the default starter app. Then we'll talk about what it does.
+After removing Blaze, let's replace the code of the default starter app. Then we'll talk about what it does.
 
 First, replace the content of the initial HTML file:
 


### PR DESCRIPTION
Added an additional step to remove Blaze templating and render static HTML. This resolves the following error which is being displayed upon completion of step 2.5:

`Target container is not a DOM element`