### PR TITLE
Replace practicalmeteor:mocha with meteortesting:mocha again

### DIFF
--- a/content/blaze/step11.md
+++ b/content/blaze/step11.md
@@ -6,16 +6,17 @@ Now that we've created a few features for our application, let's add a test to e
 
 We'll write a test that exercises one of our Methods (which form the "write" part of our app's API), and verifies it works correctly.
 
-To do so, we'll add a [test driver](http://guide.meteor.com/testing.html#test-driver) for the [Mocha](https://mochajs.org) JavaScript test framework:
+To do so, we'll add a [test driver](http://guide.meteor.com/testing.html#test-driver) for the [Mocha](https://mochajs.org) JavaScript test framework, along with a test assertion library:
 
 ```bash
-meteor add practicalmeteor:mocha
+meteor add meteortesting:mocha
+meteor npm install --save-dev chai
 ```
 
 We can now run our app in "test mode" by calling out a special command and specifying to use the driver (you'll need to stop the regular app from running, or specify an alternate port with `--port XYZ`):
 
 ```bash
-meteor test --driver-package practicalmeteor:mocha
+TEST_WATCH=1 meteor test --driver-package meteortesting:mocha
 ```
 
 If you do so, you should see an empty test results page in your browser window.


### PR DESCRIPTION
Even though this was already done in #157, it was accidentally reverted by #159 when the shared step11 was removed and blaze step11 was not updated to match

Noticed because of a comment in the forums: https://forums.meteor.com/t/how-to-add-api-secret-keys-without-revealing-them-to-the-client/44473/24