### PR TITLE
Added static-html for react, instead of blaze html

### DIFF
--- a/content/react/step02.md
+++ b/content/react/step02.md
@@ -11,6 +11,14 @@ meteor npm install --save react react-dom
 
 > Note: `meteor npm` supports the same features as `npm`, though the difference can be important.  Consult the [`meteor npm` documentation](https://docs.meteor.com/commandline.html#meteornpm) for more information.
 
+After we added the react libraries we need to remove the default blaze templating functionality, using static-html instead:
+
+```sh
+meteor remove blaze-html-templates
+meteor add static-html
+```
+
+
 ### Replace the starter code
 
 To get started, let's replace the code of the default starter app. Then we'll talk about what it does.


### PR DESCRIPTION
Added step to remove blaze html template module and replace it with static-html( otherwise, an Uncaught Error: Target container is not a DOM element. at invariant  is generated). The default blaze html templating module has to be removed, as it's conflicting with static-html