### PR TITLE
Add meteor commands to remove blaze

### DIFF
--- a/content/react/step02.md
+++ b/content/react/step02.md
@@ -7,6 +7,8 @@ Open a new terminal in the same directory as your running app, and type:
 
 ```sh
 meteor npm install --save react react-dom
+meteor remove blaze-html-templates
+meteor add static-html
 ```
 
 > Note: `meteor npm` supports the same features as `npm`, though the difference can be important.  Consult the [`meteor npm` documentation](https://docs.meteor.com/commandline.html#meteornpm) for more information.


### PR DESCRIPTION
The React tutorials fail to adequately guide the new user through Meteor + React.
Prior to this change, the UI failed with a message `Target container is not a DOM element.`
To the novice (or even experienced) developer, the solution is not obvious, and leaves a bad taste in
their mouth, along with a general mistrust of Meteor.
Add and remove appropriate meteor packages to make tutorial seamless.
Fix https://github.com/meteor/meteor/issues/9939