### PR TITLE
Revert "Add meteor commands to remove blaze"

### DIFF
--- a/content/react/step02.md
+++ b/content/react/step02.md
@@ -36,8 +36,6 @@ Open a new terminal in the same directory as your running app, and type:
 
 ```sh
 meteor npm install --save react react-dom
-meteor remove blaze-html-templates
-meteor add static-html
 ```
 
 > Note: `meteor npm` supports the same features as `npm`, though the difference can be important. Consult the [`meteor npm` documentation](https://docs.meteor.com/commandline.html#meteornpm) for more information.


### PR DESCRIPTION
Reverts meteor/tutorials#185

This was already done via https://github.com/meteor/tutorials/commit/f8549e455718ba353eb7466034cdf0e234222792!  I didn't catch it in the diffs that were displayed in GitHub.