### PR TITLE
Removing Angular Specific Recommendations

### DIFF
--- a/content/shared/nextSteps.md
+++ b/content/shared/nextSteps.md
@@ -4,7 +4,7 @@ Here are some options for where you can go next:
 
 1. Read the [Meteor Guide](http://guide.meteor.com) to learn about best practices and useful community packages
 2. Check out the [complete documentation](https://docs.meteor.com)
-3. Explore additional Meteor tutorials like [WhatsApp clone]( http://www.angular-meteor.com/tutorials/whatsapp/meteor/bootstrapping) and [Intermediate Meteor](https://www.youtube.com/watch?v=BI8IslJHSag&list=PLLnpHn493BHFYZUSK62aVycgcAouqBt7V)
+3. Explore additional Meteor content such as the [Intermediate Meteor](https://www.youtube.com/watch?v=BI8IslJHSag&list=PLLnpHn493BHFYZUSK62aVycgcAouqBt7V) video series
 
 <div class="row">
   <hr />


### PR DESCRIPTION
this was mentioned as an issue #202 and it makes sense, although I think the idea was to point you to things that were more advanced regardless of the technology used. But the shared step can be more generic if that makes more sense. I also think that the angular