### PR TITLE
Fix typo: instace -> instance

### DIFF
--- a/content/vue/step02.md
+++ b/content/vue/step02.md
@@ -91,7 +91,7 @@ We just added three things to our app:
 
 ### Define view components with Vue
 
-In Vue, single file components are created with the .vue file extension and are comprised of three sections, the script section, the template section and the style section. Within the script section you will define a Vue instance that supports the template section. This Vue instace, like the root Vue instance created in `main.js`, is fully documented in the [Vue.js Guide](https://vuejs.org/v2/guide/instance.html)
+In Vue, single file components are created with the .vue file extension and are comprised of three sections, the script section, the template section and the style section. Within the script section you will define a Vue instance that supports the template section. This Vue instance, like the root Vue instance created in `main.js`, is fully documented in the [Vue.js Guide](https://vuejs.org/v2/guide/instance.html)
 
 ### Check the result
 

--- a/content/vue/step07.md
+++ b/content/vue/step07.md
@@ -24,7 +24,7 @@ Now if you check the box, the task list will only show tasks that haven't been c
 
 ### One more feature: Showing a count of incomplete tasks
 
-Now that we have written a query that filters out completed tasks, we can use the same query to display a count of the tasks that haven't been checked off. To do this we need to fetch a count in the meteor object of the Vue instace. Since we already have the data in the client-side collection, adding this extra count doesn't involve asking the server for anything.
+Now that we have written a query that filters out completed tasks, we can use the same query to display a count of the tasks that haven't been checked off. To do this we need to fetch a count in the meteor object of the Vue instance. Since we already have the data in the client-side collection, adding this extra count doesn't involve asking the server for anything.
 
 {{> DiffBox step="7.5" tutorialName="simple-todos-vue"}}
 


### PR DESCRIPTION
A small typo in the todo-app (Vue).